### PR TITLE
feat(*): add ability to define project id or title for a task

### DIFF
--- a/tool-vikunja.py
+++ b/tool-vikunja.py
@@ -17,21 +17,40 @@ from pydantic import BaseModel, Field
 
 PRIORITY_MAP = {4: "Critical", 3: "High", 2: "Medium", 1: "Low", 0: "None"}
 
-
 class Tools:
     class Valves(BaseModel):
+        domain: str = Field("", description="Domain where Vikunja is installed, e.g. https://try.vikunja.io")
         authToken: str = Field("", description="API key")
-        projectId: str = Field("", description="Project ID")
 
     def __init__(self):
         self.valves = self.Valves()
 
-    def get_todoist_tasks(self) -> str:
+    def get_project_id(self, project_title: str = None) -> int:
+        """
+        Retrieves the project ID based on a fuzzy match of the title.
+        """
+        # If project title is provided for matching, use the default project ID
+        if not project_title:
+            return 1
+        url = f"{self.valves.domain}/api/v1/projects"
+        headers = {"Authorization": f"Bearer {self.valves.authToken}"}
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        projects = response.json()
+
+        for project in projects:
+            if project["title"].lower() == project_title.lower():
+                return project["id"]
+
+        # If no matching project title is found, use the default project ID
+        return 1
+
+    def get_vikunja_tasks(self) -> str:
         """
         Retrieves active tasks from Vikunja for a specific project.
         """
         url = (
-            f"https://todo.thompsonsj.com/api/v1/projects/{self.valves.projectId}/tasks"
+            f"{self.valves.domain}/api/v1/projects/{self.valves.projectId}/tasks"
         )
         headers = {"Authorization": f"Bearer {self.valves.authToken}"}
         response = requests.get(url, headers=headers)
@@ -51,17 +70,18 @@ class Tools:
             formatted_tasks.append(formatted_task)
         return f"```json\n{json.dumps(formatted_tasks)}\n```"
 
-    def update_todoist_task(
+    def update_vikunja_task(
         self,
         task_id: int,
         content: str = None,
         priority: int = 0,
         due_date: datetime = None,
+        project_id: int = None,
     ) -> str:
         """
         Updates a specific task in Vikunja.
         """
-        url = f"https://todo.thompsonsj.com/api/v1/projects/{self.valves.projectId}/tasks/{task_id}"
+        url = f"{self.valves.domain}/api/v1/projects/{project_id}/tasks/{task_id}"
         headers = {"Authorization": f"Bearer {self.valves.authToken}"}
         data = {}
         if content:
@@ -74,18 +94,30 @@ class Tools:
         response.raise_for_status()
         return f"Updated task {task_id} successfully."
 
-    def create_todoist_task(self, content: str, priority: int = 0) -> str:
+    def create_vikunja_task(
+        self,
+        content: str,
+        priority: int = 0,
+        due_date: str = None,
+        project_id: int = None,
+        project_title: str = None
+    ) -> str:
         """
         Creates a new task in Vikunja.
         """
+        if not project_id:
+            project_id = self.get_project_id(project_title)
         url = (
-            f"https://todo.thompsonsj.com/api/v1/projects/{self.valves.projectId}/tasks"
+            f"{self.valves.domain}/api/v1/projects/{project_id}/tasks"
         )
         headers = {"Authorization": f"Bearer {self.valves.authToken}"}
         data = {
             "title": content,
             "priority": priority,
         }
+        if due_date is not None:
+            date_obj = datetime.strptime(due_date, "%Y-%m-%d")
+            data["due_date"] = date_obj.isoformat() + "Z"
         response = requests.put(url, headers=headers, json=data)
         response.raise_for_status()
         return f"Created task with ID {response.json()['id']} successfully."


### PR DESCRIPTION
Define either a project id or a project title in your request. If a project id is defined, the LLM may use that to attach a task to that project. If a title is define, the LLM can look up the project id using a `get_project_id` function.